### PR TITLE
Add support for forerunner devices supported by API level 5.0.0

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -14,6 +14,16 @@
             "Monkey C: Edit Products" - Lets you add or remove any product
         -->
         <iq:products>
+            <iq:product id="fr165"/>
+            <iq:product id="fr165m"/>
+            <iq:product id="fr255"/>
+            <iq:product id="fr255m"/>
+            <iq:product id="fr255s"/>
+            <iq:product id="fr255sm"/>
+            <iq:product id="fr265"/>
+            <iq:product id="fr265s"/>
+            <iq:product id="fr955"/>
+            <iq:product id="fr965"/>
             <iq:product id="venu2"/>
             <iq:product id="venu2plus"/>
             <iq:product id="venu2s"/>


### PR DESCRIPTION
This adds support for the forerunner devices supported by the used API  level (currently 5.0.0). This should greatly improve the amount of people that can take advantage of the app. 
