### PR TITLE
Add support for Forerunner 245 devices

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -5,7 +5,7 @@
         Use "Monkey C: Edit Application" from the Visual Studio Code command palette
         to update the application attributes.
     -->
-    <iq:application id="f8e8f4e6-90d7-4c1d-9a9e-47ce969743dc" type="watch-app" name="@Strings.AppName" entry="BreastfeedTrackerApp" launcherIcon="@Drawables.LauncherIcon" minApiLevel="5.0.0">
+    <iq:application id="f8e8f4e6-90d7-4c1d-9a9e-47ce969743dc" type="watch-app" name="@Strings.AppName" entry="BreastfeedTrackerApp" launcherIcon="@Drawables.LauncherIcon" minApiLevel="3.3.0">
         <!--
             Use the following from the Visual Studio Code comand palette to edit
             the build targets:
@@ -18,6 +18,8 @@
             <iq:product id="approachs7047mm"/>
             <iq:product id="fr165"/>
             <iq:product id="fr165m"/>
+            <iq:product id="fr245"/>
+            <iq:product id="fr245m"/>
             <iq:product id="fr255"/>
             <iq:product id="fr255m"/>
             <iq:product id="fr255s"/>

--- a/resources/layouts/about_layout.xml
+++ b/resources/layouts/about_layout.xml
@@ -2,5 +2,5 @@
     <label id="AppName" text="@Strings.AppName" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="17%"/>
     <label id="MadeBy" text="Robbin Voortman" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="33%"/>
     <label id="License" text="MIT Licensed" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="50%"/>
-    <label id="Version" text="v1.2.0" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="66%"/>
+    <label id="Version" text="v1.2.1" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="66%"/>
 </layout>

--- a/source/BreastfeedTrackerDelegate.mc
+++ b/source/BreastfeedTrackerDelegate.mc
@@ -27,8 +27,8 @@ class BreastfeedTrackerDelegate extends WatchUi.BehaviorDelegate {
     }
 
     function onTap(clickEvent) as Boolean {
-        var deviceWidth = Rez.Styles.device_info.screenWidth;
-        var deviceHeight = Rez.Styles.device_info.screenHeight;
+        var deviceWidth = System.getDeviceSettings().screenWidth;
+        var deviceHeight = System.getDeviceSettings().screenHeight;
         var helper = new BreastfeedTrackerHelper();
 
         if (clickEvent.getType() == WatchUi.CLICK_TYPE_TAP) {


### PR DESCRIPTION
## Description
This adds basic support for Forerunner 245 devices and opens up support for a lot more 'older' devices. 

There are still some existing problems: the text on the homescreen does not reflect that you need to press the menu button to add new feedings and the homescreen buttons can go away now and make room for more feedings (making #21 more accessible)

## Related Issues
Ref #21 
Ref #14

## How to Test
1. Build the device for the Forerunner 245
2. Open it up and use it!
