### PR TITLE
Automatically format 12/24 hour time formats

### DIFF
--- a/resources/layouts/about_layout.xml
+++ b/resources/layouts/about_layout.xml
@@ -2,5 +2,5 @@
     <label id="AppName" text="@Strings.AppName" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="17%"/>
     <label id="MadeBy" text="Robbin Voortman" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="33%"/>
     <label id="License" text="MIT Licensed" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="50%"/>
-    <label id="Version" text="v1.5.1" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="66%"/>
+    <label id="Version" text="v1.5.2" justification="Graphics.TEXT_JUSTIFY_CENTER" font="Gfx.FONT_SMALL" x="center" y="66%"/>
 </layout>

--- a/source/BreastfeedTrackerHelper.mc
+++ b/source/BreastfeedTrackerHelper.mc
@@ -6,6 +6,7 @@ using Toybox.System;
 using Toybox.Time;
 using Toybox.Time.Gregorian;
 
+(:glance)
 class BreastfeedTrackerHelper {
     const STORAGE_KEY = "feedings";
     const MAX_HISTORY = 30;
@@ -72,8 +73,26 @@ class BreastfeedTrackerHelper {
 
         var moment = new Time.Moment(feeding["timestamp"] as Number);
         var timeInfo = Gregorian.info(moment, Time.FORMAT_SHORT);
-        var minutes = timeInfo.min < 10 ? "0" + timeInfo.min : timeInfo.min;
-        var timeString = Lang.format("$1$:$2$", [timeInfo.hour, minutes]);
+
+        var deviceSettings = System.getDeviceSettings();
+        var timeString;
+        if (deviceSettings.is24Hour) {
+            timeString = Lang.format("$1$:$2$", [
+                timeInfo.hour.format("%02d"),
+                timeInfo.min.format("%02d"),
+            ]);
+        } else {
+            var hour = timeInfo.hour;
+            var ampm = hour >= 12 ? "PM" : "AM";
+            if (hour > 12) {
+                hour = hour - 12;
+            }
+            timeString = Lang.format("$1$:$2$ $3$", [
+                hour,
+                timeInfo.min.format("%02d"),
+                ampm,
+            ]);
+        }
 
         var type = feeding["type"] as Char;
         var label = "";

--- a/source/glance/Glance.mc
+++ b/source/glance/Glance.mc
@@ -6,6 +6,8 @@ using Toybox.WatchUi;
 
 (:glance)
 class Glance extends WatchUi.GlanceView {
+    var helper as BreastfeedTrackerHelper = new BreastfeedTrackerHelper();
+
     function initialize() {
         GlanceView.initialize();
     }
@@ -40,34 +42,8 @@ class Glance extends WatchUi.GlanceView {
             var secondFeeding =
                 feedings.size() > 1 ? feedings[feedings.size() - 2] : null;
 
-            feedingOneLabel.setText(formatFeeding(currentFeeding));
-            feedingTwoLabel.setText(formatFeeding(secondFeeding));
+            feedingOneLabel.setText(helper.formatFeeding(currentFeeding));
+            feedingTwoLabel.setText(helper.formatFeeding(secondFeeding));
         }
-    }
-
-    // This function is duplicated from BrestfeedTrackerHelper.mc because
-    // the glance view cannot access the BreastfeedTrackerHelper class directly.
-    function formatFeeding(feeding as Dictionary?) as String {
-        if (feeding == null) {
-            return "";
-        }
-
-        var moment = new Time.Moment(feeding["timestamp"] as Number);
-        var timeInfo = Gregorian.info(moment, Time.FORMAT_SHORT);
-        var minutes = timeInfo.min < 10 ? "0" + timeInfo.min : timeInfo.min;
-        var timeString = Lang.format("$1$:$2$", [timeInfo.hour, minutes]);
-
-        var type = feeding["type"] as Char;
-        var label = "";
-
-        if (type == 'l') {
-            label = Application.loadResource(Rez.Strings.left);
-        } else if (type == 'r') {
-            label = Application.loadResource(Rez.Strings.right);
-        } else if (type == 'b') {
-            label = Application.loadResource(Rez.Strings.bottle);
-        }
-
-        return timeString + " - " + label;
     }
 }


### PR DESCRIPTION
## Description
Our American friends use 12 hour notation. The app did not support that. Now it automatically formats the time the same as the system.

Furthermore, it seems we actually _can_ use the helper in the glance view, but I was not capable enough to do that previously. Now I am!

## Related Issues
Fixes #40 

## Screenshots (if applicable)
<img width="240" height="240" alt="ampm" src="https://github.com/user-attachments/assets/d98c09f3-2035-4ffc-9ce9-94a8a5e92d1e" />

## How to Test
Set the simulator time from 12 to 24 and back. See the times in the history view, the main view and the glance view all change.
